### PR TITLE
Fixing React Invalid DOM warnings.

### DIFF
--- a/components/UserProfile.tsx
+++ b/components/UserProfile.tsx
@@ -28,9 +28,9 @@ export default function UserProfile() {
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
-            fill-rule="evenodd"
+            fillRule="evenodd"
             d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"
-            clip-rule="evenodd"
+            clipRule="evenodd"
           ></path>
         </svg>
         Sign In


### PR DESCRIPTION
Fixes the warnings in the console log:

- Warning: Invalid DOM property `fill-rule`. Did you mean `fillRule`?
- Warning: Invalid DOM property `clip-rule`. Did you mean `clipRule`?